### PR TITLE
SAK-2907

### DIFF
--- a/message/message-api/api/src/java/org/sakaiproject/message/api/MessageService.java~
+++ b/message/message-api/api/src/java/org/sakaiproject/message/api/MessageService.java~
@@ -251,7 +251,7 @@ public interface MessageService extends EntityProducer, EntitySummary
 	/**
 	 * Cancel the changes made to a MessageEdit object, and release the lock. The MessageEdit is disabled, and not to be used after this call.
 	 * 
-	 * @param edit
+	 * @param user
 	 *        The MessageEdit object to cancel.
 	 */
 	public void cancelMessage(MessageEdit edit);


### PR DESCRIPTION
squashed : Clarified documentation for MessageService.java
squashed : fixed incorrect verbage on a @param annotation
