### PR TITLE
Fixed login toolbar height issue (SAK-30489)

### DIFF
--- a/reference/library/src/morpheus-master/sass/modules/_toolmenu.scss
+++ b/reference/library/src/morpheus-master/sass/modules/_toolmenu.scss
@@ -3,7 +3,7 @@ body.is-logged-out{
 	#toolMenuWrap{
 		//top: 0;
 		@media #{$phone}{
-			top: $header-size;
+			//top: $header-size;
 		}
 	}
 	.#{$namespace}mainHeader.is-maximized ~ #container #toolMenuWrap{

--- a/reference/library/src/morpheus-master/sass/modules/navigation/_base.scss
+++ b/reference/library/src/morpheus-master/sass/modules/navigation/_base.scss
@@ -13,7 +13,7 @@ body.is-logged-out{
 	}
 	.#{$namespace}topHeader{
 		@media #{$phone}{
-			min-height:4.2em;
+			min-height: $header-size;
 		}
 	}
 }


### PR DESCRIPTION
Fixed an issue leading to the login toolbar overlapping to element below it before authentication (see the bug on [Jira](https://jira.sakaiproject.org/browse/SAK-30489))
